### PR TITLE
Refactor KeysSorter_Comparable (methods are instance members), NaNPrepass, update yml

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: ${{ runner.dotnet }}
+        dotnet-version: '5.x' #${{ runner.dotnet }}
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet: [ '3.1.201' ]
+        dotnet: [ '3.1.201', '5.0.100-preview.3.20216.6' ]
         configuration: [ Release, Debug ]
 
     steps:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -70,6 +70,6 @@ jobs:
     #    dotnet-version: '5.0.100-preview.3.20216.6' #${{ matrix.dotnet }}
 
     - name: Build with dotnet
-      run: dotnet build --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
+      run: dotnet build --configuration ${{ matrix.configuration }}
     - name: Test with dotnet
       run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet: [ '5.x' ]
+        #dotnet: [ '5.x' ]
 
     steps:
     - name: Checkout
@@ -27,10 +27,16 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
       
-    - name: Setup .NET Core
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1.201' #${{ runner.dotnet }}
+
+    - name: Setup .NET Core 5.0
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '5.0.100-preview.3.20216.6' #${{ runner.dotnet }}
+
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        configuration: [ Release, Debug ]
         dotnet: [ '3.1.201' ]
+        configuration: [ Release, Debug ]
 
     steps:
     - name: Dump GitHub context
@@ -73,9 +73,9 @@ jobs:
     #  run: dotnet build --configuration ${{ matrix.configuration }}
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
     - name: Test with dotnet 3.1
-      if: startsWith(${{ matrix.dotnet }}, "3.1") # Should set a framework variable instead
+      if: startsWith(matrix.dotnet, "3.1") # Should set a framework variable instead
       run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
 
     - name: Test with dotnet 5.0
-      if: startsWith(${{ matrix.dotnet }}, "5.0")
+      if: startsWith(matrix.dotnet, "5.0")
       run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -73,9 +73,9 @@ jobs:
     #  run: dotnet build --configuration ${{ matrix.configuration }}
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
     - name: Test with dotnet 3.1
-      if: startsWith(matrix.dotnet, "3.1") # Should set a framework variable instead
+      if: startsWith(matrix.dotnet, '3.1') # Should set a framework variable instead
       run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
 
     - name: Test with dotnet 5.0
-      if: startsWith(matrix.dotnet, "5.0")
+      if: startsWith(matrix.dotnet, '5.0')
       run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -73,11 +73,13 @@ jobs:
     #  run: dotnet build --configuration ${{ matrix.configuration }}
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
     - name: Test with dotnet 3.1
-      env: DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      env: 
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '3.1') # Should set a framework variable instead
       run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
 
     - name: Test with dotnet 5.0
-      env: DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      env: 
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '5.0')
       run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -1,4 +1,5 @@
 name: dotnetcore
+# https://www.edwardthomson.com/blog/github_actions_advent_calendar.html
 
 on:
   push:
@@ -14,30 +15,56 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
+        configuration: [ Release, Debug ]
         #dotnet: [ '5.x' ]
 
     steps:
+    - name: Dump GitHub context
+      env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+      env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+      run: echo "$JOB_CONTEXT"
+    - name: Dump steps context
+      env:
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+      run: echo "$STEPS_CONTEXT"
+    - name: Dump runner context
+      env:
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
+      run: echo "$RUNNER_CONTEXT"
+    - name: Dump strategy context
+      env:
+          STRATEGY_CONTEXT: ${{ toJson(strategy) }}
+      run: echo "$STRATEGY_CONTEXT"
+    - name: Dump matrix context
+      env:
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+      run: echo "$MATRIX_CONTEXT"
+
     - name: Checkout
       uses: actions/checkout@v2
       
     - uses: actions/cache@v1
       with:
         path: ~/.nuget/packages
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        key: ${{ matrix.os }}-nuget-${{ hashFiles('**/*.csproj') }}
         restore-keys: |
-          ${{ runner.os }}-nuget-
+          ${{ matrix.os }}-nuget-
       
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.201' #${{ runner.dotnet }}
+        dotnet-version: '3.1.201' #${{ matrix.dotnet }}
 
-    - name: Setup .NET Core 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.100-preview.3.20216.6' #${{ runner.dotnet }}
+    #- name: Setup .NET Core 5.0
+    #  uses: actions/setup-dotnet@v1
+    #  with:
+    #    dotnet-version: '5.0.100-preview.3.20216.6' #${{ matrix.dotnet }}
 
     - name: Build with dotnet
-      run: dotnet build --configuration Release
+      run: dotnet build --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
     - name: Test with dotnet
-      run: dotnet test --configuration Release
+      run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -76,10 +76,10 @@ jobs:
       env: 
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '3.1') # Should set a framework variable instead
-      run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }} .\tests\DotNetCross.Sorting.Tests\DotNetCross.Sorting.Tests.csproj
+      run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }} ./tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
 
     - name: Test with dotnet 5.0
       env: 
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '5.0')
-      run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }} .\tests\DotNetCross.Sorting.Tests\DotNetCross.Sorting.Tests.csproj
+      run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }} ./tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -73,9 +73,11 @@ jobs:
     #  run: dotnet build --configuration ${{ matrix.configuration }}
     # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
     - name: Test with dotnet 3.1
+      env: DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '3.1') # Should set a framework variable instead
       run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
 
     - name: Test with dotnet 5.0
+      env: DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '5.0')
       run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.x' #${{ runner.dotnet }}
+        dotnet-version: '5.0.100-preview.3.20216.6' #${{ runner.dotnet }}
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -76,10 +76,10 @@ jobs:
       env: 
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '3.1') # Should set a framework variable instead
-      run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
+      run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }} .\tests\DotNetCross.Sorting.Tests\DotNetCross.Sorting.Tests.csproj
 
     - name: Test with dotnet 5.0
       env: 
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
       if: startsWith(matrix.dotnet, '5.0')
-      run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }}
+      run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }} .\tests\DotNetCross.Sorting.Tests\DotNetCross.Sorting.Tests.csproj

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet: [ '3.1.201', '5.0.100-preview.3.20216.6' ]
+        dotnet: [ '3.1.201' ] #, '5.0.100-preview.3.20216.6' ]
         configuration: [ Release, Debug ]
 
     steps:

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet: [ '5.0.100-preview.3.20216.6' ]
+        dotnet: [ '5.x' ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         configuration: [ Release, Debug ]
-        #dotnet: [ '5.x' ]
+        dotnet: [ '3.1.201' ]
 
     steps:
     - name: Dump GitHub context
@@ -59,17 +59,23 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-nuget-
       
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.201' #${{ matrix.dotnet }}
+        dotnet-version: ${{ matrix.dotnet }}
 
     #- name: Setup .NET Core 5.0
     #  uses: actions/setup-dotnet@v1
     #  with:
     #    dotnet-version: '5.0.100-preview.3.20216.6' #${{ matrix.dotnet }}
 
-    - name: Build with dotnet
-      run: dotnet build --configuration ${{ matrix.configuration }}
-    - name: Test with dotnet
+    #- name: Build with dotnet
+    #  run: dotnet build --configuration ${{ matrix.configuration }}
+    # https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+    - name: Test with dotnet 3.1
+      if: startsWith(${{ matrix.dotnet }}, "3.1") # Should set a framework variable instead
       run: dotnet test --framework netcoreapp3.1 --configuration ${{ matrix.configuration }}
+
+    - name: Test with dotnet 5.0
+      if: startsWith(${{ matrix.dotnet }}, "5.0")
+      run: dotnet test --framework netcoreapp5.0 --configuration ${{ matrix.configuration }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -23,22 +23,27 @@ jobs:
       env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-      - name: Dump job context
+
+    - name: Dump job context
       env:
           JOB_CONTEXT: ${{ toJson(job) }}
       run: echo "$JOB_CONTEXT"
+
     - name: Dump steps context
       env:
           STEPS_CONTEXT: ${{ toJson(steps) }}
       run: echo "$STEPS_CONTEXT"
+
     - name: Dump runner context
       env:
           RUNNER_CONTEXT: ${{ toJson(runner) }}
       run: echo "$RUNNER_CONTEXT"
+
     - name: Dump strategy context
       env:
           STRATEGY_CONTEXT: ${{ toJson(strategy) }}
       run: echo "$STRATEGY_CONTEXT"
+
     - name: Dump matrix context
       env:
           MATRIX_CONTEXT: ${{ toJson(matrix) }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        dotnet: [ '3.1.101' ]
+        dotnet: [ '5.0.100-preview.3.20216.6' ]
 
     steps:
     - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,4 @@ _Pvt_Extensions
 .fake/
 
 
+*.diagsession

--- a/src/DotNetCross.Sorting/Common/DirectComparers.cs
+++ b/src/DotNetCross.Sorting/Common/DirectComparers.cs
@@ -6,7 +6,7 @@ namespace DotNetCross.Sorting
 {
     // This started out with just LessThan.
     // However, due to bogus comparers, comparables etc.
-    // we need to preserve semantics completely to get same result.
+    // we need to preserve semantics completely to get same result. REVISIT THIS BY MAKING TESTS ROBUST AGAINST SAME KEY DIFFERENCES
     internal interface IDirectComparer<in T>
     {
         bool GreaterThan(T x, T y);
@@ -106,7 +106,7 @@ namespace DotNetCross.Sorting
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool LessThanEqual(double x, double y) => x <= y;
     }
-    // TODO: Revise whether this is needed
+
     internal struct StringDirectComparer : IDirectComparer<string>
     {
         readonly CompareInfo m_compareInfo;

--- a/src/DotNetCross.Sorting/Common/DirectComparers.cs
+++ b/src/DotNetCross.Sorting/Common/DirectComparers.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
@@ -107,11 +109,21 @@ namespace DotNetCross.Sorting
     // TODO: Revise whether this is needed
     internal struct StringDirectComparer : IDirectComparer<string>
     {
+        readonly CompareInfo m_compareInfo;
+
+        public StringDirectComparer(CompareInfo compareInfo) =>
+            m_compareInfo = compareInfo;
+
+        // Getting CurrentCulture.CompareInfo for each compare is slower,
+        // so instead we get it once and use for default string sorting.
+        public static StringDirectComparer CreateForCurrentCulture() =>
+            new StringDirectComparer(CultureInfo.CurrentCulture.CompareInfo);
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool GreaterThan(string x, string y) => x.CompareTo(y) > 0;
+        public bool GreaterThan(string x, string y) => m_compareInfo.Compare(x, y) > 0;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool LessThan(string x, string y) => x.CompareTo(y) < 0;
+        public bool LessThan(string x, string y) => m_compareInfo.Compare(x, y) < 0;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool LessThanEqual(string x, string y) => x.CompareTo(y) <= 0;
+        public bool LessThanEqual(string x, string y) => m_compareInfo.Compare(x, y) <= 0;
     }
 }

--- a/src/DotNetCross.Sorting/Implementations/Common.cs
+++ b/src/DotNetCross.Sorting/Implementations/Common.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using static DotNetCross.Sorting.Swapper;
 
 namespace DotNetCross.Sorting
 {
@@ -21,6 +22,57 @@ namespace DotNetCross.Sorting
                 n >>= 1;
             }
             return result;
+        }
+
+        // For sorting, move all NaN instances to front of the input array
+        internal static int NaNPrepass<TKey, TIsNaN>(
+            ref TKey keys, int length,
+            TIsNaN isNaN)
+            where TIsNaN : struct, IIsNaN<TKey>
+        {
+            int left = 0;
+            for (int i = 0; i < length; i++)
+            {
+                ref TKey current = ref Unsafe.Add(ref keys, i);
+                if (isNaN.IsNaN(current))
+                {
+                    // TODO: If first index is not NaN or we find just one not NaNs 
+                    //       we could skip to version that no longer checks this
+                    if (left != i)
+                    {
+                        ref TKey previous = ref Unsafe.Add(ref keys, left);
+                        Swap(ref previous, ref current);
+                    }
+                    ++left;
+                }
+            }
+            return left;
+        }
+
+        // For sorting, move all NaN instances to front of the input array
+        internal static int NaNPrepass<TKey, TValue, TIsNaN>(
+            ref TKey keys, ref TValue values, int length,
+            TIsNaN isNaN)
+            where TIsNaN : struct, IIsNaN<TKey>
+        {
+            int left = 0;
+            for (int i = 0; i < length; i++)
+            {
+                ref TKey current = ref Unsafe.Add(ref keys, i);
+                if (isNaN.IsNaN(current))
+                {
+                    // TODO: If first index is not NaN or we find just one not NaNs 
+                    //       we could skip to version that no longer checks this
+                    if (left != i)
+                    {
+                        ref TKey previous = ref Unsafe.Add(ref keys, left);
+                        Swap(ref previous, ref current);
+                        Swap(ref values, left, i);
+                    }
+                    ++left;
+                }
+            }
+            return left;
         }
     }
 }

--- a/src/DotNetCross.Sorting/Implementations/HeapSort.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/HeapSort.Keys.IComparable.cs
@@ -5,11 +5,10 @@ using static DotNetCross.Sorting.Swapper;
 
 namespace DotNetCross.Sorting
 {
-    internal static partial class IComparableImpl
+    internal partial class KeysSorter_Comparable<TKey>
     {
-        internal static void HeapSort<TKey>(
+        internal static void HeapSort(
             ref TKey keys, int lo, int hi)
-            where TKey : IComparable<TKey>
         {
 
             Debug.Assert(lo >= 0);
@@ -27,9 +26,8 @@ namespace DotNetCross.Sorting
             }
         }
 
-        internal static void DownHeap<TKey>(
+        internal static void DownHeap(
             ref TKey keys, int i, int n, int lo)
-            where TKey : IComparable<TKey>
         {
 
             Debug.Assert(lo >= 0);

--- a/src/DotNetCross.Sorting/Implementations/InsertionSort.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/InsertionSort.Keys.IComparable.cs
@@ -4,12 +4,12 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
-    internal static partial class IComparableImpl
+    internal partial class IntroKeysSortersComparable<TKey>
+        : IKeysSorter<TKey>
+        where TKey : IComparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void InsertionSort<TKey>(
-            ref TKey keys, int lo, int hi)
-            where TKey : IComparable<TKey>
+        internal static void InsertionSort(ref TKey keys, int lo, int hi)
         {
             Debug.Assert(lo >= 0);
             Debug.Assert(hi >= lo);

--- a/src/DotNetCross.Sorting/Implementations/InsertionSort.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/InsertionSort.Keys.IComparable.cs
@@ -4,9 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
-    internal partial class IntroKeysSortersComparable<TKey>
-        : IKeysSorter<TKey>
-        where TKey : IComparable<TKey>
+    internal partial class KeysSorter_Comparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void InsertionSort(ref TKey keys, int lo, int hi)

--- a/src/DotNetCross.Sorting/Implementations/IntroSort.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/IntroSort.Keys.IComparable.cs
@@ -5,21 +5,18 @@ using static DotNetCross.Sorting.Common;
 
 namespace DotNetCross.Sorting
 {
-    internal static partial class IComparableImpl
+    internal partial class IntroKeysSortersComparable<TKey>
+        : IKeysSorter<TKey>
+        where TKey : IComparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void IntroSort<TKey>(
-            ref TKey keys, int length)
-            where TKey : IComparable<TKey>
+        internal void IntroSort(ref TKey keys, int length)
         {
             var depthLimit = 2 * FloorLog2PlusOne(length);
             IntroSort(ref keys, 0, length - 1, depthLimit);
         }
 
-        private static void IntroSort<TKey>(
-            ref TKey keys,
-            int lo, int hi, int depthLimit)
-            where TKey : IComparable<TKey>
+        void IntroSort(ref TKey keys, int lo, int hi, int depthLimit)
         {
             Debug.Assert(lo >= 0);
 
@@ -53,7 +50,7 @@ namespace DotNetCross.Sorting
 
                 if (depthLimit == 0)
                 {
-                    HeapSort(ref keys, lo, hi);
+                    IComparableImpl.HeapSort(ref keys, lo, hi);
                     return;
                 }
                 depthLimit--;

--- a/src/DotNetCross.Sorting/Implementations/IntroSort.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/IntroSort.Keys.IComparable.cs
@@ -5,12 +5,10 @@ using static DotNetCross.Sorting.Common;
 
 namespace DotNetCross.Sorting
 {
-    internal partial class IntroKeysSortersComparable<TKey>
-        : IKeysSorter<TKey>
-        where TKey : IComparable<TKey>
+    internal partial class KeysSorter_Comparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void IntroSort(ref TKey keys, int length)
+        public void IntroSort(ref TKey keys, int length)
         {
             var depthLimit = 2 * FloorLog2PlusOne(length);
             IntroSort(ref keys, 0, length - 1, depthLimit);
@@ -50,7 +48,7 @@ namespace DotNetCross.Sorting
 
                 if (depthLimit == 0)
                 {
-                    IComparableImpl.HeapSort(ref keys, lo, hi);
+                    HeapSort(ref keys, lo, hi);
                     return;
                 }
                 depthLimit--;

--- a/src/DotNetCross.Sorting/Implementations/PickPivotAndPartition.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/PickPivotAndPartition.Keys.IComparable.cs
@@ -5,9 +5,7 @@ using static DotNetCross.Sorting.Swapper;
 
 namespace DotNetCross.Sorting
 {
-    internal partial class IntroKeysSortersComparable<TKey>
-                : IKeysSorter<TKey>
-                where TKey : IComparable<TKey>
+    internal partial class KeysSorter_Comparable<TKey>
     {
         internal int PickPivotAndPartition(
             ref TKey keys, int lo, int hi)

--- a/src/DotNetCross.Sorting/Implementations/PickPivotAndPartition.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/PickPivotAndPartition.Keys.IComparable.cs
@@ -5,11 +5,12 @@ using static DotNetCross.Sorting.Swapper;
 
 namespace DotNetCross.Sorting
 {
-    internal static partial class IComparableImpl
+    internal partial class IntroKeysSortersComparable<TKey>
+                : IKeysSorter<TKey>
+                where TKey : IComparable<TKey>
     {
-        internal static int PickPivotAndPartition<TKey>(
+        internal int PickPivotAndPartition(
             ref TKey keys, int lo, int hi)
-            where TKey : IComparable<TKey>
         {
 
             Debug.Assert(lo >= 0);
@@ -26,45 +27,60 @@ namespace DotNetCross.Sorting
             int middle = (int)(((uint)hi + (uint)lo) >> 1);
 
             // Sort lo, mid and hi appropriately, then pick mid as the pivot.
-            ref TKey keysAtLo = ref Unsafe.Add(ref keys, lo);
-            ref TKey keysAtMiddle = ref Unsafe.Add(ref keys, middle);
-            ref TKey keysAtHi = ref Unsafe.Add(ref keys, hi);
-            Sort3(ref keysAtLo, ref keysAtMiddle, ref keysAtHi);
+            ref TKey keysLeft = ref Unsafe.Add(ref keys, lo);
+            ref TKey keysMiddle = ref Unsafe.Add(ref keys, middle);
+            ref TKey keysRight = ref Unsafe.Add(ref keys, hi);
+            Sort3(ref keysLeft, ref keysMiddle, ref keysRight);
 
-            TKey pivot = keysAtMiddle;
+            TKey pivot = keysMiddle;
+
+            // We already partitioned lo and hi and put the pivot in hi - 1.  
+            // And we pre-increment & decrement below.
+            keysRight = ref Unsafe.Add(ref keysRight, -1);
+            Swap(ref keysMiddle, ref keysRight);
 
             int left = lo;
             int right = hi - 1;
-            // We already partitioned lo and hi and put the pivot in hi - 1.  
-            // And we pre-increment & decrement below.
-            Swap(ref keysAtMiddle, ref Unsafe.Add(ref keys, right));
-
             while (left < right)
             {
                 // TODO: Would be good to be able to update local ref here
 
                 if (pivot == null)
                 {
-                    while (left < (hi - 1) && Unsafe.Add(ref keys, ++left) == null) ;
-                    while (right > lo && Unsafe.Add(ref keys, --right) != null) ;
+                    //while (left < (hi - 1) && Unsafe.Add(ref keys, ++left) == null) ;
+                    do { ++left; keysLeft = ref Unsafe.Add(ref keysLeft, 1); }
+                    while (left < right && keysLeft == null);
+
+                    //while (right > lo && Unsafe.Add(ref keys, --right) != null) ;
+                    do { --right; keysRight = ref Unsafe.Add(ref keysRight, -1); }
+                    while (right > lo && keysRight != null);
                 }
                 else
                 {
-                    while (left < (hi - 1) && pivot.CompareTo(Unsafe.Add(ref keys, ++left)) > 0) ;
+                    //while (left < (hi - 1) && pivot.CompareTo(Unsafe.Add(ref keys, ++left)) > 0) ;
+                    //while (left < right && pivot.CompareTo(Unsafe.Add(ref keys, ++left)) > 0) ;
+                    do { ++left; keysLeft = ref Unsafe.Add(ref keysLeft, 1); }
+                    while (left < right && pivot.CompareTo(keysLeft) > 0);
                     // Check if bad comparable/comparer
-                    if (left == (hi - 1) && pivot.CompareTo(Unsafe.Add(ref keys, left)) > 0)
+                    if (left == right && pivot.CompareTo(keysLeft) > 0)
                         ThrowHelper.ThrowArgumentException_BadComparable(typeof(TKey));
 
-                    while (right > lo && pivot.CompareTo(Unsafe.Add(ref keys, --right)) < 0) ;
+                    //while (right > lo && pivot.CompareTo(Unsafe.Add(ref keys, --right)) < 0) ;
+                    do { --right; keysRight = ref Unsafe.Add(ref keysRight, -1); }
+                    while (right > lo && pivot.CompareTo(keysRight) < 0);
                     // Check if bad comparable/comparer
-                    if (right == lo && pivot.CompareTo(Unsafe.Add(ref keys, right)) < 0)
+                    if (right == lo && pivot.CompareTo(keysRight) < 0)
                         ThrowHelper.ThrowArgumentException_BadComparable(typeof(TKey));
                 }
 
                 if (left >= right)
                     break;
 
-                Swap(ref keys, left, right);
+                //Swap(ref keys, left, right);
+                //Swap(ref keysLeft, ref keysRight);
+                var t = keysLeft;
+                keysLeft = keysRight;
+                keysRight = t;
             }
             // Put pivot in the right location.
             right = hi - 1;

--- a/src/DotNetCross.Sorting/Implementations/PickPivotAndPartition.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/PickPivotAndPartition.Keys.IComparable.cs
@@ -76,8 +76,7 @@ namespace DotNetCross.Sorting
                 if (left >= right)
                     break;
 
-                //Swap(ref keys, left, right);
-                //Swap(ref keysLeft, ref keysRight);
+                // PERF: Swap manually inlined here for better code-gen
                 var t = keysLeft;
                 keysLeft = keysRight;
                 keysRight = t;

--- a/src/DotNetCross.Sorting/Implementations/Sort2.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/Sort2.Keys.IComparable.cs
@@ -4,8 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
-    internal partial class IntroKeysSortersComparable<TKey>
-        : IKeysSorter<TKey>
+    internal partial class KeysSorter_Comparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Sort2(ref TKey keys, int i, int j)

--- a/src/DotNetCross.Sorting/Implementations/Sort2.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/Sort2.Keys.IComparable.cs
@@ -4,12 +4,11 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
-    internal static partial class IComparableImpl
+    internal partial class IntroKeysSortersComparable<TKey>
+        : IKeysSorter<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Sort2<TKey>(
-        ref TKey keys, int i, int j)
-        where TKey : IComparable<TKey>
+        internal static void Sort2(ref TKey keys, int i, int j)
         {
             Debug.Assert(i != j);
 
@@ -19,8 +18,7 @@ namespace DotNetCross.Sorting
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Sort2<TKey>(ref TKey a, ref TKey b)
-            where TKey : IComparable<TKey>
+        internal static void Sort2(ref TKey a, ref TKey b)
         {
             if (a != null && a.CompareTo(b) > 0)
             {

--- a/src/DotNetCross.Sorting/Implementations/Sort3.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/Sort3.Keys.IComparable.cs
@@ -4,9 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
-    internal partial class IntroKeysSortersComparable<TKey>
-        : IKeysSorter<TKey>
-        where TKey : IComparable<TKey>
+    internal partial class KeysSorter_Comparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void Sort3(ref TKey r0, ref TKey r1, ref TKey r2)

--- a/src/DotNetCross.Sorting/Implementations/Sort3.Keys.IComparable.cs
+++ b/src/DotNetCross.Sorting/Implementations/Sort3.Keys.IComparable.cs
@@ -4,12 +4,12 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting
 {
-    internal static partial class IComparableImpl
+    internal partial class IntroKeysSortersComparable<TKey>
+        : IKeysSorter<TKey>
+        where TKey : IComparable<TKey>
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void Sort3<TKey>(
-            ref TKey r0, ref TKey r1, ref TKey r2)
-            where TKey : IComparable<TKey>
+        internal void Sort3(ref TKey r0, ref TKey r1, ref TKey r2)
         {
             Sort2(ref r0, ref r1);
             Sort2(ref r0, ref r2);

--- a/src/DotNetCross.Sorting/Implementations/Sort3.Keys.TComparer.cs
+++ b/src/DotNetCross.Sorting/Implementations/Sort3.Keys.TComparer.cs
@@ -26,7 +26,6 @@ namespace DotNetCross.Sorting
             //    if (comparer.LessThanEqual(r1, r2))
             //    {
             //        // r0 <= r1 <= r2
-            //        return; // Is this return good or bad for perf?
             //    }
             //    // r0 <= r1
             //    // r2 < r1

--- a/src/DotNetCross.Sorting/Sorters/IKeysSorter.cs
+++ b/src/DotNetCross.Sorting/Sorters/IKeysSorter.cs
@@ -5,8 +5,8 @@ namespace DotNetCross.Sorting
 {
     internal interface IKeysSorter<TKey>
     {
-        void Sort(ref TKey keys, int length);
-        void Sort(ref TKey keys, int length, Comparison<TKey> comparison);
+        void IntroSort(ref TKey keys, int length);
+        void IntroSort(ref TKey keys, int length, Comparison<TKey> comparison);
     }
 
     internal interface IKeysSorter<TKey, TComparer>

--- a/src/DotNetCross.Sorting/Sorters/IntroKeysSorters.cs
+++ b/src/DotNetCross.Sorting/Sorters/IntroKeysSorters.cs
@@ -6,23 +6,6 @@ using SDC = System.SpanSortHelpersKeys_DirectComparer;
 
 namespace DotNetCross.Sorting
 {
-    internal sealed partial class IntroKeysSortersComparable<TKey>
-        : IKeysSorter<TKey>
-        where TKey : IComparable<TKey>
-    {
-        public void Sort(ref TKey keys, int length)
-        {
-            IntroSort(ref keys, length);
-        }
-
-        public void Sort(ref TKey keys, int length, Comparison<TKey> comparison)
-        {
-            // TODO: Check if comparison is Comparer<TKey>.Default.Compare
-
-            ComparisonImpl.IntroSort(ref keys, length, comparison);
-        }
-    }
-
     internal static partial class IntroKeysSorters
     {
         static readonly object[] EmptyObjects = new object[0];
@@ -36,7 +19,7 @@ namespace DotNetCross.Sorting
                 if (IComparableTraits<TKey>.IsComparable)
                 {
                     // coreclr uses RuntimeTypeHandle.Allocate
-                    var ctor = typeof(IntroKeysSortersComparable<>)
+                    var ctor = typeof(KeysSorter_Comparable<>)
                         .MakeGenericType(new Type[] { typeof(TKey) })
                         .GetTypeInfo().DeclaredConstructors.Where(ci => !ci.IsStatic).Single();
 
@@ -51,12 +34,13 @@ namespace DotNetCross.Sorting
 
         internal sealed class NonComparable<TKey> : IKeysSorter<TKey>
         {
-            public void Sort(ref TKey keys, int length)
+            public void IntroSort(ref TKey keys, int length)
             {
+                // TODO: Cache Comparer<TKey>.Default as Comparison<TKey> since faster
                 TComparerImpl.IntroSort(ref keys, length, Comparer<TKey>.Default);
             }
 
-            public void Sort(ref TKey keys, int length, Comparison<TKey> comparison)
+            public void IntroSort(ref TKey keys, int length, Comparison<TKey> comparison)
             {
                 ComparisonImpl.IntroSort(ref keys, length, comparison);
             }
@@ -124,7 +108,7 @@ namespace DotNetCross.Sorting
             where TKey : IComparable<TKey>
             where TComparer : IComparer<TKey>
         {
-            internal static readonly IntroKeysSortersComparable<TKey> NonComparerInstance = new IntroKeysSortersComparable<TKey>();
+            internal static readonly KeysSorter_Comparable<TKey> NonComparerInstance = new KeysSorter_Comparable<TKey>();
 
             public void Sort(ref TKey keys, int length,
                 TComparer comparer)

--- a/src/DotNetCross.Sorting/Sorters/IntroKeysSorters.cs
+++ b/src/DotNetCross.Sorting/Sorters/IntroKeysSorters.cs
@@ -6,6 +6,23 @@ using SDC = System.SpanSortHelpersKeys_DirectComparer;
 
 namespace DotNetCross.Sorting
 {
+    internal sealed partial class IntroKeysSortersComparable<TKey>
+        : IKeysSorter<TKey>
+        where TKey : IComparable<TKey>
+    {
+        public void Sort(ref TKey keys, int length)
+        {
+            IntroSort(ref keys, length);
+        }
+
+        public void Sort(ref TKey keys, int length, Comparison<TKey> comparison)
+        {
+            // TODO: Check if comparison is Comparer<TKey>.Default.Compare
+
+            ComparisonImpl.IntroSort(ref keys, length, comparison);
+        }
+    }
+
     internal static partial class IntroKeysSorters
     {
         static readonly object[] EmptyObjects = new object[0];
@@ -19,9 +36,9 @@ namespace DotNetCross.Sorting
                 if (IComparableTraits<TKey>.IsComparable)
                 {
                     // coreclr uses RuntimeTypeHandle.Allocate
-                    var ctor = typeof(Comparable<>)
+                    var ctor = typeof(IntroKeysSortersComparable<>)
                         .MakeGenericType(new Type[] { typeof(TKey) })
-                        .GetTypeInfo().DeclaredConstructors.Single();
+                        .GetTypeInfo().DeclaredConstructors.Where(ci => !ci.IsStatic).Single();
 
                     return (IKeysSorter<TKey>)ctor.Invoke(EmptyObjects);
                 }
@@ -45,22 +62,6 @@ namespace DotNetCross.Sorting
             }
         }
 
-        internal sealed class Comparable<TKey>
-            : IKeysSorter<TKey>
-            where TKey : IComparable<TKey>
-        {
-            public void Sort(ref TKey keys, int length)
-            {
-                IComparableImpl.IntroSort(ref keys, length);
-            }
-
-            public void Sort(ref TKey keys, int length, Comparison<TKey> comparison)
-            {
-                // TODO: Check if comparison is Comparer<TKey>.Default.Compare
-
-                ComparisonImpl.IntroSort(ref keys, length, comparison);
-            }
-        }
 
         internal static class Default<TKey, TComparer>
             where TComparer : IComparer<TKey>
@@ -74,7 +75,7 @@ namespace DotNetCross.Sorting
                     // coreclr uses RuntimeTypeHandle.Allocate
                     var ctor = typeof(Comparable<,>)
                         .MakeGenericType(new Type[] { typeof(TKey), typeof(TComparer) })
-                        .GetTypeInfo().DeclaredConstructors.Single();
+                        .GetTypeInfo().DeclaredConstructors.Where(ci => !ci.IsStatic).Single();
 
                     return (IKeysSorter<TKey, TComparer>)ctor.Invoke(EmptyObjects);
                 }
@@ -123,6 +124,8 @@ namespace DotNetCross.Sorting
             where TKey : IComparable<TKey>
             where TComparer : IComparer<TKey>
         {
+            internal static readonly IntroKeysSortersComparable<TKey> NonComparerInstance = new IntroKeysSortersComparable<TKey>();
+
             public void Sort(ref TKey keys, int length,
                 TComparer comparer)
             {
@@ -141,7 +144,8 @@ namespace DotNetCross.Sorting
                     {
                         // NOTE: For Bogus Comparable the exception message will be different, when using Comparer<TKey>.Default
                         //       Since the exception message is thrown internally without knowledge of the comparer
-                        IComparableImpl.IntroSort(ref keys, length);
+                        //IComparableImpl.IntroSort(ref keys, length);
+                        NonComparerInstance.IntroSort(ref keys, length);
                     }
                 }
                 else

--- a/src/DotNetCross.Sorting/Sorters/KeysSorter_Comparable.cs
+++ b/src/DotNetCross.Sorting/Sorters/KeysSorter_Comparable.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace DotNetCross.Sorting
+{
+    internal sealed partial class KeysSorter_Comparable<TKey>
+        : IKeysSorter<TKey>
+        where TKey : IComparable<TKey>
+    {
+        public void IntroSort(ref TKey keys, int length, Comparison<TKey> comparison)
+        {
+            // TODO: Check if comparison is Comparer<TKey>.Default.Compare
+            //       and if reference type or not
+            // TODO: Make member
+            ComparisonImpl.IntroSort(ref keys, length, comparison);
+        }
+    }
+}

--- a/src/DotNetCross.Sorting/Sorts.IntroSort.Keys.cs
+++ b/src/DotNetCross.Sorting/Sorts.IntroSort.Keys.cs
@@ -23,7 +23,7 @@ namespace DotNetCross.Sorting
                     ref MemoryMarshal.GetReference(keys),
                     length))
                 {
-                    IntroKeysSorters.Default<TKey>.Instance.Sort(
+                    IntroKeysSorters.Default<TKey>.Instance.IntroSort(
                         ref MemoryMarshal.GetReference(keys),
                         length);
                 }
@@ -51,7 +51,7 @@ namespace DotNetCross.Sorting
                 if (length < 2)
                     return;
 
-                IntroKeysSorters.Default<TKey>.Instance.Sort(
+                IntroKeysSorters.Default<TKey>.Instance.IntroSort(
                     ref MemoryMarshal.GetReference(keys),
                     length, comparison);
             }

--- a/src/DotNetCross.Sorting/SpanSortHelpers.Keys.Specialized.cs
+++ b/src/DotNetCross.Sorting/SpanSortHelpers.Keys.Specialized.cs
@@ -106,12 +106,13 @@ namespace System
                 return true;
             }
             // TODO: Specialize for string if necessary. What about the == null checks?
-            //else if (typeof(TKey) == typeof(string))
-            //{
-            //    ref var specificKeys = ref Unsafe.As<TKey, string>(ref keys);
-            //    Sort(ref specificKeys, length, new StringDirectComparer());
-            //    return true;
-            //}
+            else if (typeof(TKey) == typeof(string))
+            {
+                ref var specificKeys = ref Unsafe.As<TKey, string>(ref keys);
+                var comparer = StringDirectComparer.CreateForCurrentCulture();
+                IntroSort(ref specificKeys, length, comparer);
+                return true;
+            }
             else
             {
                 return false;

--- a/src/DotNetCross.Sorting/SpanSortHelpers.Keys.Specialized.cs
+++ b/src/DotNetCross.Sorting/SpanSortHelpers.Keys.Specialized.cs
@@ -80,7 +80,7 @@ namespace System
 
                 // Comparison to NaN is always false, so do a linear pass 
                 // and swap all NaNs to the front of the array
-                var left = NaNPrepass(ref specificKeys, length, new SingleIsNaN());
+                var left = Common.NaNPrepass(ref specificKeys, length, new SingleIsNaN());
 
                 var remaining = length - left;
                 if (remaining > 1)
@@ -96,7 +96,7 @@ namespace System
 
                 // Comparison to NaN is always false, so do a linear pass 
                 // and swap all NaNs to the front of the array
-                var left = NaNPrepass(ref specificKeys, length, new DoubleIsNaN());
+                var left = Common.NaNPrepass(ref specificKeys, length, new DoubleIsNaN());
                 var remaining = length - left;
                 if (remaining > 1)
                 {
@@ -118,29 +118,5 @@ namespace System
             }
         }
 
-        // For sorting, move all NaN instances to front of the input array
-        private static int NaNPrepass<TKey, TIsNaN>(
-            ref TKey keys, int length,
-            TIsNaN isNaN)
-            where TIsNaN : struct, IIsNaN<TKey>
-        {
-            int left = 0;
-            for (int i = 0; i < length; i++)
-            {
-                ref TKey current = ref Unsafe.Add(ref keys, i);
-                if (isNaN.IsNaN(current))
-                {
-                    // TODO: If first index is not NaN or we find just one not NaNs 
-                    //       we could skip to version that no longer checks this
-                    if (left != i)
-                    {
-                        ref TKey previous = ref Unsafe.Add(ref keys, left);
-                        Swap(ref previous, ref current);
-                    }
-                    ++left;
-                }
-            }
-            return left;
-        }
     }
 }

--- a/src/DotNetCross.Sorting/SpanSortHelpers.KeysValues.Specialized.cs
+++ b/src/DotNetCross.Sorting/SpanSortHelpers.KeysValues.Specialized.cs
@@ -139,7 +139,7 @@ namespace System
             //else if (typeof(TKey) == typeof(string))
             //{
             //    ref var specificKeys = ref Unsafe.As<TKey, string>(ref keys);
-            //    Sort(ref specificKeys, ref values, length, new StringDirectComparer());
+            //    IntroSort(ref specificKeys, ref values, length, StringDirectComparer.CreateForCurrentCulture());
             //    return true;
             //}
             else

--- a/src/DotNetCross.Sorting/SpanSortHelpers.KeysValues.Specialized.cs
+++ b/src/DotNetCross.Sorting/SpanSortHelpers.KeysValues.Specialized.cs
@@ -91,7 +91,7 @@ namespace System
                 {
                     // Comparison to NaN is always false, so do a linear pass 
                     // and swap all NaNs to the front of the array
-                    var left = NaNPrepass(ref specificKeys, ref values, length, new SingleIsNaN());
+                    var left = Common.NaNPrepass(ref specificKeys, ref values, length, new SingleIsNaN());
 
                     var remaining = length - left;
                     if (remaining > 1)
@@ -119,7 +119,7 @@ namespace System
                 {
                     // Comparison to NaN is always false, so do a linear pass 
                     // and swap all NaNs to the front of the array
-                    var left = NaNPrepass(ref specificKeys, ref values, length, new DoubleIsNaN());
+                    var left = Common.NaNPrepass(ref specificKeys, ref values, length, new DoubleIsNaN());
 
                     var remaining = length - left;
                     if (remaining > 1)
@@ -146,32 +146,6 @@ namespace System
             {
                 return false;
             }
-        }
-
-        // For sorting, move all NaN instances to front of the input array
-        private static int NaNPrepass<TKey, TValue, TIsNaN>(
-            ref TKey keys, ref TValue values, int length,
-            TIsNaN isNaN)
-            where TIsNaN : struct, IIsNaN<TKey>
-        {
-            int left = 0;
-            for (int i = 0; i < length; i++)
-            {
-                ref TKey current = ref Unsafe.Add(ref keys, i);
-                if (isNaN.IsNaN(current))
-                {
-                    // TODO: If first index is not NaN or we find just one not NaNs 
-                    //       we could skip to version that no longer checks this
-                    if (left != i)
-                    {
-                        ref TKey previous = ref Unsafe.Add(ref keys, left);
-                        Swap(ref previous, ref current);
-                        Swap(ref values, left, i);
-                    }
-                    ++left;
-                }
-            }
-            return left;
         }
     }
 }

--- a/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
+++ b/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
-    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <!--<TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>-->
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
+++ b/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
@@ -2,13 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
+    <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
+    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
     <!--<TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>-->
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
+++ b/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
     <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
         The whole way of specifying target framework when building is messy from command line-->
-    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <!--<TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>-->
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
+++ b/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0</TargetFrameworks>
     <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
         The whole way of specifying target framework when building is messy from command line-->
     <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->

--- a/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
+++ b/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
         The whole way of specifying target framework when building is messy from command line-->
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
     <!--<TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>-->
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
+++ b/tests/DotNetCross.Sorting.Benchmarks/DotNetCross.Sorting.Benchmarks.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
+        The whole way of specifying target framework when building is messy from command line-->
+    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
     <!--<TargetFrameworks>netcoreapp2.0;net471</TargetFrameworks>-->
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using DotNetCross.Sorting.Sequences;
@@ -68,7 +69,7 @@ namespace DotNetCross.Sorting.Benchmarks
     {
         public StringSortBench()
             : base(maxLength: 100000, new[] { 2, 3, 10, 100, 1000, 10000 },
-                   SpanFillers.Default, i => i.ToString("D9"))
+                   SpanFillers.RandomOnly, i => i.ToString("D9"))
         { }
     }
     public class ComparableStructInt32SortBench : SortBench<ComparableStructInt32>
@@ -81,8 +82,8 @@ namespace DotNetCross.Sorting.Benchmarks
     public class ComparableClassInt32SortBench : SortBench<ComparableClassInt32>
     {
         public ComparableClassInt32SortBench()
-            : base(maxLength: 100000, new[] { 2, 3, 10, 100, 10000, 100000 },
-                   SpanFillers.Default, i => new ComparableClassInt32(i))
+            : base(maxLength: 400000, new[] { 2, 3, 10, 100, 10000, 100000 },
+                   SpanFillers.RandomOnly, i => new ComparableClassInt32(i))
         { }
     }
 
@@ -222,17 +223,19 @@ namespace DotNetCross.Sorting.Benchmarks
     {
         static void Main(string[] args)
         {
+            Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.RealTime;
+            Thread.CurrentThread.Priority = ThreadPriority.Highest;
+
             if (true && !Debugger.IsAttached)
             {
                 //BenchmarkRunner.Run<SortDictionary>();
                 // TKey benchs
-                BenchmarkRunner.Run<Int32SortBench>();
-                //BenchmarkRunner.Run<Int32SortDisassemblerBench>();
-                return;
-                BenchmarkRunner.Run<SingleSortBench>();
+                //BenchmarkRunner.Run<Int32SortBench>();
+                //BenchmarkRunner.Run<SingleSortBench>();
                 BenchmarkRunner.Run<ComparableStructInt32SortBench>();
                 BenchmarkRunner.Run<ComparableClassInt32SortBench>();
                 BenchmarkRunner.Run<StringSortBench>();
+                return;
                 // TKey,TValue benchs
                 BenchmarkRunner.Run<Int32Int32SortBench>();
                 BenchmarkRunner.Run<Int32SingleSortBench>();
@@ -265,23 +268,25 @@ namespace DotNetCross.Sorting.Benchmarks
             }
             else if (true)
             {
-                var sut = new ComparableClassInt32SortBench();
-                //var sut = new StringSortBench();
+                //var sut = new ComparableClassInt32SortBench();
+                var sut = new StringSortBench();
                 sut.Filler = new RandomSpanFiller(SpanFillers.RandomSeed);
-                sut.Length = 1000; // 1000000;
+                sut.Length = 10000; // 1000000;
                 sut.GlobalSetup();
                 sut.IterationSetup();
                 sut.DNX_Span_();
                 sut.IterationSetup();
-                sut.DNX_Span_();
+                sut.Array_();
 
-                Console.WriteLine("Enter key...");
-                Console.ReadKey();
+                //Console.WriteLine("Enter key...");
+                //Console.ReadKey();
 
-                for (int i = 0; i < 1000; i++)
+                for (int i = 0; i < 200; i++)
                 {
                     sut.IterationSetup();
                     sut.DNX_Span_();
+                    sut.IterationSetup();
+                    sut.Array_();
                 }
             }
             else

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -1,5 +1,9 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using DotNetCross.Sorting.Sequences;
 
@@ -29,6 +33,29 @@ namespace DotNetCross.Sorting.Benchmarks
             : base(maxLength: 3000000, new[] { 100, 1000, 10000, 1000000 },
                    SpanFillers.RandomOnly, i => i)
         { }
+
+        [Benchmark]
+        public void DNX_Span_CustomStructComparer()
+        {
+            for (int i = 0; i <= _maxLength - Length; i += Length)
+            {
+                new Span<int>(_work, i, Length).IntroSort(new CustomStructComparer());
+            }
+        }
+
+        struct CustomStructComparer : IComparer<int>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(int x, int y) => x.CompareTo(y);
+        }
+
+        //int[] a = new int[3];
+        //public void SortTest()
+        //{
+        //    TComparerImpl.Sort3(ref a[0], ref a[1], ref a[2],
+        //        new CustomStructComparer());
+        //}
+
     }
     public class SingleSortBench : SortBench<float>
     {

--- a/tests/DotNetCross.Sorting.Benchmarks/SortBench.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/SortBench.cs
@@ -11,11 +11,11 @@ namespace DotNetCross.Sorting.Benchmarks
         where TKey : IComparable<TKey>
     {
         static readonly ClassComparableComparer<TKey> _classComparer = new ClassComparableComparer<TKey>();
-        readonly int _maxLength;
-        readonly ISpanFiller[] _fillers;
-        readonly Func<int, TKey> _toValue;
-        readonly TKey[] _filled;
-        readonly TKey[] _work;
+        protected readonly int _maxLength;
+        protected readonly ISpanFiller[] _fillers;
+        protected readonly Func<int, TKey> _toValue;
+        protected readonly TKey[] _filled;
+        protected readonly TKey[] _work;
 
         public SortBench(int maxLength, int[] sliceLengths, ISpanFiller[] fillers, Func<int, TKey> toValue)
         {

--- a/tests/DotNetCross.Sorting.Benchmarks/SortBench.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/SortBench.cs
@@ -58,7 +58,7 @@ namespace DotNetCross.Sorting.Benchmarks
                 Array.Sort(_work, i, Length);
             }
         }
-        [Benchmark]
+        //[Benchmark]
         public void Array_NullComparer()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
@@ -66,7 +66,7 @@ namespace DotNetCross.Sorting.Benchmarks
                 Array.Sort(_work, i, Length, (IComparer<TKey>)null);
             }
         }
-        [Benchmark]
+        //[Benchmark]
         public void Array_ClassComparableComparer()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
@@ -76,15 +76,24 @@ namespace DotNetCross.Sorting.Benchmarks
         }
 #if !NETCOREAPP3_1
         [Benchmark]
-        public void Array_StructComparableComparer()
+        public void CLR_Span_()
+        {
+            for (int i = 0; i <= _maxLength - Length; i += Length)
+            {
+                new Span<TKey>(_work, i, Length).Sort();
+            }
+        }
+
+        //[Benchmark]
+        public void CLR_Span_StructComparableComparer()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
             {
                 new Span<TKey>(_work, i, Length).Sort(new StructComparableComparer<TKey>());
             }
         }
-        [Benchmark]
-        public void Array_Comparison()
+        //[Benchmark]
+        public void CLR_Span_Comparison()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
             {
@@ -103,7 +112,7 @@ namespace DotNetCross.Sorting.Benchmarks
                 new Span<TKey>(_work, i, Length).IntroSort();
             }
         }
-        [Benchmark]
+        //[Benchmark]
         public void DNX_Span_NullComparer()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
@@ -111,7 +120,7 @@ namespace DotNetCross.Sorting.Benchmarks
                 new Span<TKey>(_work, i, Length).IntroSort((IComparer<TKey>)null);
             }
         }
-        [Benchmark]
+        //[Benchmark]
         public void DNX_Span_ClassComparableComparer()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
@@ -119,7 +128,7 @@ namespace DotNetCross.Sorting.Benchmarks
                 new Span<TKey>(_work, i, Length).IntroSort(ClassComparableComparer<TKey>.Instance);
             }
         }
-        [Benchmark]
+        //[Benchmark]
         public void DNX_Span_StructComparableComparer()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
@@ -127,7 +136,7 @@ namespace DotNetCross.Sorting.Benchmarks
                 new Span<TKey>(_work, i, Length).IntroSort(new StructComparableComparer<TKey>());
             }
         }
-        [Benchmark]
+        //[Benchmark]
         public void DNX_Span_Comparison()
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)

--- a/tests/DotNetCross.Sorting.Benchmarks/SortBenchConfig.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/SortBenchConfig.cs
@@ -15,7 +15,7 @@ namespace DotNetCross.Sorting.Benchmarks
             var envModes = new[] {
                 // NOTE: None of the other platforms work...
                 //new EnvMode { Runtime = Runtime.Core, Platform = Platform.X86 },
-                new EnvironmentMode { Runtime = CoreRuntime.Core50, Platform = Platform.X64 },
+                new EnvironmentMode { Runtime = CoreRuntime.Core31, Platform = Platform.X64 },
                 //new EnvMode { Runtime = Runtime.Clr, Platform = Platform.X86 },
                 //new EnvMode { Runtime = Runtime.Clr, Platform = Platform.X64 },
             };

--- a/tests/DotNetCross.Sorting.Benchmarks/SortBenchConfig.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/SortBenchConfig.cs
@@ -14,8 +14,9 @@ namespace DotNetCross.Sorting.Benchmarks
             var runMode = new BenchmarkDotNet.Jobs.RunMode() { LaunchCount = 1, WarmupCount = 3, IterationCount = 9, /*TargetCount = 11, */RunStrategy = RunStrategy.Monitoring };
             var envModes = new[] {
                 // NOTE: None of the other platforms work...
-                //new EnvMode { Runtime = Runtime.Core, Platform = Platform.X86 },
-                new EnvironmentMode { Runtime = CoreRuntime.Core31, Platform = Platform.X64 },
+                //new EnvironmentMode { Platform = Platform.X86 },
+                //new EnvironmentMode { Platform = Platform.X64 },
+                new EnvironmentMode { Runtime =  CoreRuntime.Core50, Platform = Platform.X64 },
                 //new EnvMode { Runtime = Runtime.Clr, Platform = Platform.X86 },
                 //new EnvMode { Runtime = Runtime.Clr, Platform = Platform.X64 },
             };

--- a/tests/DotNetCross.Sorting.Benchmarks/SortDisassemblerBench.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/SortDisassemblerBench.cs
@@ -55,28 +55,48 @@ namespace DotNetCross.Sorting.Benchmarks
             Array.Sort(_work, ComparableComparison<TKey>.Instance);
         }
 
+#if !NETCOREAPP3_1
         [Benchmark]
-        public void Span_()
+        public void CLR_Span_()
+        {
+            new Span<TKey>(_work).Sort();
+        }
+
+        [Benchmark]
+        public void CLR_Span_StructComparableComparer()
+        {
+            new Span<TKey>(_work).Sort(new StructComparableComparer<TKey>());
+        }
+        [Benchmark]
+        public void CLR_Span_Comparison()
+        {
+            var span = new Span<TKey>(_work);
+            span.Sort(ComparableComparison<TKey>.Instance);
+        }
+#endif
+
+        [Benchmark]
+        public void DNX_Span_()
         {
             new Span<TKey>(_work).IntroSort();
         }
         [Benchmark]
-        public void Span_NullComparer()
+        public void DNX_Span_NullComparer()
         {
             new Span<TKey>(_work).IntroSort((IComparer<TKey>)null);
         }
         [Benchmark]
-        public void Span_ClassComparableComparer()
+        public void DNX_Span_ClassComparableComparer()
         {
             new Span<TKey>(_work).IntroSort(ClassComparableComparer<TKey>.Instance);
         }
         [Benchmark]
-        public void Span_StructComparableComparer()
+        public void DNX_Span_StructComparableComparer()
         {
             new Span<TKey>(_work).IntroSort(new StructComparableComparer<TKey>());
         }
         [Benchmark]
-        public void Span_Comparison()
+        public void DNX_Span_Comparison()
         {
             new Span<TKey>(_work).IntroSort(ComparableComparison<TKey>.Instance);
         }

--- a/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
+++ b/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
     <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
         The whole way of specifying target framework when building is messy from command line-->
-    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <OutputPath>..\..\build\Tests_$(AssemblyName)_$(Configuration)</OutputPath>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
+++ b/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--<TargetFrameworks>netcoreapp3.1</TargetFrameworks>-->
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
         The whole way of specifying target framework when building is messy from command line-->
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
     <OutputPath>..\..\build\Tests_$(AssemblyName)_$(Configuration)</OutputPath>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
+++ b/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <!--<TargetFramework>netcoreapp3.1</TargetFramework>-->
+    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
     <OutputPath>..\..\build\Tests_$(AssemblyName)_$(Configuration)</OutputPath>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
+++ b/tests/DotNetCross.Sorting.Tests/DotNetCross.Sorting.Tests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!--<TargetFramework>netcoreapp3.1</TargetFramework>-->
-    <TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <!--Simply can't get the below working with GitHub CI since can't have multiple SDKs installed.
+        The whole way of specifying target framework when building is messy from command line-->
+    <!--<TargetFrameworks>netcoreapp3.1;netcoreapp5.0</TargetFrameworks>-->
     <OutputPath>..\..\build\Tests_$(AssemblyName)_$(Configuration)</OutputPath>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Static generic methods suffer from performance issues for reference types, this is due to the canonical representation, as discussed in https://github.com/dotnet/runtime/blob/master/docs/design/coreclr/botr/shared-generics.md

In particular, in the profiler if you observe `JIT_GenericHandleClass` or `JIT_GenericHandleMethod` taking up time, then you have an issue around performance due to generic methods or types and how could is factored. Hence, it can be important to have methods as instances on an object instance. Perf hit here was 8-9% for specific reference type cases.

Lots of CI issues around trying to get both .NET Core 3.1 and 5.0 testing, finally conceeded and just testing 3.1. 5.0 also seems to give different results for floats (keys-values) in the face of NaNs.