### PR TITLE
Fix nuget package issues, brainstorm unification as TDirectComparer

### DIFF
--- a/src/DotNetCross.Sorting/Common/DelegateDoctor.cs
+++ b/src/DotNetCross.Sorting/Common/DelegateDoctor.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace DotNetCross.Sorting
+{
+    internal static class DelegateDoctor
+    {
+        internal static Comparison<T> GetComparableCompareToAsOpenDelegate<T>()
+            where T : class, IComparable<T>
+        {
+            var paramType = typeof(T);
+            var comparableType = typeof(T);
+            const string methodName = nameof(IComparable<T>.CompareTo);
+            var methodInfo = comparableType.GetRuntimeMethod(methodName, new Type[] { paramType });
+
+            var comparison = (Comparison<T>)methodInfo.CreateDelegate(typeof(Comparison<T>));
+
+            return comparison;
+        }
+
+        internal static Comparison<object> GetComparableCompareToAsOpenObjectDelegate<T>()
+            where T : class, IComparable<T>
+        {
+            var comparison = GetComparableCompareToAsOpenDelegate<T>();
+            return Unsafe.As<Comparison<object>>(comparison);
+        }
+    }
+}

--- a/src/DotNetCross.Sorting/Common/DelegateDoctor.cs
+++ b/src/DotNetCross.Sorting/Common/DelegateDoctor.cs
@@ -23,10 +23,32 @@ namespace DotNetCross.Sorting
             return comparison;
         }
 
+        internal static Comparison<T> GetIComparableCompareToAsOpenDelegate<T>()
+            where T : class, IComparable<T>
+        {
+            var paramType = typeof(T);
+            var comparableType = typeof(IComparable<T>);
+            const string methodName = nameof(IComparable<T>.CompareTo);
+            // TODO: There may be multiple methods with the given name... and type, we have to
+            //       match the interface
+            var methodInfo = comparableType.GetRuntimeMethod(methodName, new Type[] { paramType });
+
+            var comparison = (Comparison<T>)methodInfo.CreateDelegate(typeof(Comparison<T>));
+
+            return comparison;
+        }
+
         internal static Comparison<object> GetComparableCompareToAsOpenObjectDelegate<T>()
             where T : class, IComparable<T>
         {
             var comparison = GetComparableCompareToAsOpenDelegate<T>();
+            return Unsafe.As<Comparison<object>>(comparison);
+        }
+
+        internal static Comparison<object> GetIComparableCompareToAsOpenObjectDelegate<T>()
+            where T : class, IComparable<T>
+        {
+            var comparison = GetIComparableCompareToAsOpenDelegate<T>();
             return Unsafe.As<Comparison<object>>(comparison);
         }
     }

--- a/src/DotNetCross.Sorting/Common/DelegateDoctor.cs
+++ b/src/DotNetCross.Sorting/Common/DelegateDoctor.cs
@@ -14,6 +14,8 @@ namespace DotNetCross.Sorting
             var paramType = typeof(T);
             var comparableType = typeof(T);
             const string methodName = nameof(IComparable<T>.CompareTo);
+            // TODO: There may be multiple methods with the given name... and type, we have to
+            //       match the interface
             var methodInfo = comparableType.GetRuntimeMethod(methodName, new Type[] { paramType });
 
             var comparison = (Comparison<T>)methodInfo.CreateDelegate(typeof(Comparison<T>));

--- a/src/DotNetCross.Sorting/DotNetCross.Sorting.csproj
+++ b/src/DotNetCross.Sorting/DotNetCross.Sorting.csproj
@@ -15,7 +15,7 @@
 
     <!-- nuget related properties -->
     <Authors>nietras</Authors>
-    <Description></Description>
+    <Description>Fast sorting for managed/unmanaged arrays for most .NET runtimes.</Description>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>0.1.0.0</FileVersion>
     <Version>0.1.0-preview.1</Version>
@@ -34,8 +34,10 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>DotNetCross.Sorting.Tests</_Parameter1>
     </AssemblyAttribute>
-    <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Include="System.Memory" Version="4.5.4"  />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <!--https://github.com/dotnet/standard/issues/601-->
+    <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotNetCross.Sorting/DotNetCross.Sorting.csproj
+++ b/src/DotNetCross.Sorting/DotNetCross.Sorting.csproj
@@ -15,7 +15,7 @@
 
     <!-- nuget related properties -->
     <Authors>nietras</Authors>
-    <Description>Fast sorting for managed/unmanaged arrays for most .NET runtimes.</Description>
+    <Description>Fast generic sorting for managed/unmanaged arrays for most .NET runtimes.</Description>
     <AssemblyVersion>0.1.0.0</AssemblyVersion>
     <FileVersion>0.1.0.0</FileVersion>
     <Version>0.1.0-preview.1</Version>

--- a/src/DotNetCross.Sorting/DotNetCross.Sorting.csproj
+++ b/src/DotNetCross.Sorting/DotNetCross.Sorting.csproj
@@ -34,7 +34,7 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>DotNetCross.Sorting.Tests</_Parameter1>
     </AssemblyAttribute>
-    <PackageReference Include="System.Memory" Version="4.5.4"  />
+    <PackageReference Include="System.Memory" Version="4.5.4" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <!--https://github.com/dotnet/standard/issues/601-->
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />

--- a/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
@@ -83,6 +83,11 @@ namespace DotNetCross.Sorting.Benchmarks
     //   IL_0012:  ret
     // } // end of method CompareToLessThanBench`1::DISASSEMBLE
 
+    // IL_00ad:  ldloca.s pivot
+    // IL_00af:  ldloc.0
+    // IL_00b0:  ldobj      !TKey
+    // IL_00b5:  constrained. !TKey
+    // IL_00bb:  callvirt instance int32 class [System.Runtime] System.IComparable`1<!TKey>::CompareTo(!0)
 
     // ```antlr
     // pointer_type

--- a/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
@@ -30,4 +30,7 @@ namespace DotNetCross.Sorting.Benchmarks
     // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.signaturehelper?redirectedfrom=MSDN&view=netcore-3.1
 
     // https://github.com/ltrzesniewski/InlineIL.Fody/blob/master/src/InlineIL.Tests.UnverifiableAssemblyToProcess/StandAloneMethodSigTestCases.cs
+
+    // Series on calls in C#
+    // https://blog.adamfurmanek.pl/2016/05/21/virtual-and-non-virtual-calls-in-c/
 }

--- a/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 
 namespace DotNetCross.Sorting.Benchmarks
 {
+    // https://github.com/dotnet/csharplang/blob/master/proposals/function-pointers.md
+
     // Asked Tanner Gooding:
     // https://github.com/dotnet/runtime/issues/23062#issuecomment-622456190
 
@@ -33,4 +35,82 @@ namespace DotNetCross.Sorting.Benchmarks
 
     // Series on calls in C#
     // https://blog.adamfurmanek.pl/2016/05/21/virtual-and-non-virtual-calls-in-c/
+
+    // Examples
+    // https://github.com/migueldeicaza/mono-wasm-mono/blob/master/mono/tests/metadata-verifier/assembly-with-calli.il
+    // .method public static int32 SimpleMethod(int32 foo) cil managed
+    // {
+    //     ldc.i4.0
+    //     ret
+    // }
+    // .method public static void MethodWithCalli() cil managed
+    // {
+    //     ldftn int32 class Program::SimpleMethod(int32)
+    //     ldc.i4.1
+    //     calli unmanaged cdecl int32(int32)
+    //     pop
+    //     ret
+    // }
+
+
+    // Proposed Unsafe naming schema.
+
+    //public static TResult Calli_[CALLCONV]_Delegate_[Func|Action]_[Open]<T1, T2, TResult>(IntPtr functionPtr, T1 arg1, T2 arg2)
+    //{ }
+
+    //public static TResult Calli_Managed_Func_Open<T1, T2, TResult>(IntPtr functionPtr, T1 arg1, T2 arg2)
+    //{ }
+
+    // [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    // public static TResult DISASSEMBLE<TDelegate, T1, T2, TResult>(TDelegate compare, T1 x, T2 y)
+    //     where TDelegate : class, System.Delegate
+    //     => Unsafe.As<Func<T1, T2, TResult>>(compare)(x, y);
+    //
+    // .method public hidebysig static !!TResult
+    //         DISASSEMBLE<class ([System.Runtime] System.Delegate) TDelegate,T1,T2,TResult>(!!TDelegate compare,
+    //                                                                                      !!T1 x,
+    //                                                                                      !!T2 y) cil managed aggressiveinlining
+    // {
+    //   // Code size       19 (0x13)
+    //   .maxstack  8
+    //   IL_0000:  ldarg.0
+    //   IL_0001:  box        !!TDelegate
+    //   IL_0006:  call       !!0 [System.Runtime.CompilerServices.Unsafe] System.Runtime.CompilerServices.Unsafe::As<class [System.Runtime] System.Func`3<!!1,!!2,!!3>>(object)
+    //   IL_000b:  ldarg.1
+    //   IL_000c:  ldarg.2
+    //   IL_000d:  callvirt instance !2 class [System.Runtime] System.Func`3<!!T1,!!T2,!!TResult>::Invoke(!0,
+    //                                                                                                     !1)
+    //   IL_0012:  ret
+    // } // end of method CompareToLessThanBench`1::DISASSEMBLE
+
+
+    // ```antlr
+    // pointer_type
+    //     : ...
+    //     | funcptr_type
+    //     ;
+    // 
+    // funcptr_type
+    //     : 'delegate' '*' calling_convention? '<' (funcptr_parameter_modifier? type ',')* funcptr_return_modifier? return_type '>'
+    //     ;
+    // 
+    // calling_convention
+    //     : 'cdecl'
+    //     | 'managed'
+    //     | 'stdcall'
+    //     | 'thiscall'
+    //     | 'unmanaged'
+    //     ;
+    // 
+    // funcptr_parameter_modifier
+    //     : 'ref'
+    //     | 'out'
+    //     | 'in'
+    //     ;
+    // 
+    // funcptr_return_modifier
+    //     : 'ref'
+    //     | 'ref readonly'
+    //     ;
+    // ```
 }

--- a/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Calli.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DotNetCross.Sorting.Benchmarks
+{
+    // Asked Tanner Gooding:
+    // https://github.com/dotnet/runtime/issues/23062#issuecomment-622456190
+
+    // https://github.com/dotnet/runtime/issues/23062
+    // https://github.com/dotnet/corert/blob/master/src/Common/src/TypeSystem/IL/Stubs/CalliIntrinsic.cs
+    // Bing uses ldftn + calli: https://devblogs.microsoft.com/dotnet/bing-com-runs-on-net-core-2-1/
+    class Calli
+    {
+        // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldftn?redirectedfrom=MSDN&view=netcore-3.1
+        // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.ldvirtftn?redirectedfrom=MSDN&view=netcore-3.1
+        // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.calli?redirectedfrom=MSDN&view=netcore-3.1
+    }
+    // https://stackoverflow.com/questions/14006427/how-to-save-a-methodinfo-pointer-and-later-call-that-function/14008352#14008352
+    // https://stackoverflow.com/questions/15187039/using-calli-to-invoke-a-member-function
+    // https://stackoverflow.com/questions/55534030/msil-opcode-ldftn-vs-runtimemethodhandle
+
+    // https://stackoverflow.com/questions/3527917/call-a-method-using-a-methodinfo-instance-on-the-stack-using-reflection-emit/3528106#3528106
+    // don’t pass around MethodInfo instances.You could, for example, 
+    // pass managed function pointers instead.Those are the things that the ldftn and ldvirtftn instructions return. 
+    // You can then use the calli instruction to invoke one of those. You will need to construct the “call-site description”, 
+    // which calli expects as an operand, using the SignatureHelper class.
+    // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.emit.signaturehelper?redirectedfrom=MSDN&view=netcore-3.1
+
+    // https://github.com/ltrzesniewski/InlineIL.Fody/blob/master/src/InlineIL.Tests.UnverifiableAssemblyToProcess/StandAloneMethodSigTestCases.cs
+}

--- a/tests/DotNetCross.Sorting.Benchmarks/ComparableClassInt32.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/ComparableClassInt32.cs
@@ -3,19 +3,16 @@ using System.Runtime.CompilerServices;
 
 namespace DotNetCross.Sorting.Benchmarks
 {
-    public class ComparableClassInt32 : IComparable<ComparableClassInt32>
+    public class ComparableClassInt32 
+        : IComparable<ComparableClassInt32>
     {
         public readonly int Value;
 
-        public ComparableClassInt32(int value)
-        {
+        public ComparableClassInt32(int value) =>
             Value = value;
-        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int CompareTo(ComparableClassInt32 other)
-        {
-            return this.Value.CompareTo(other.Value);
-        }
+        public int CompareTo(ComparableClassInt32 other) => 
+            Value.CompareTo(other.Value);
     }
 }

--- a/tests/DotNetCross.Sorting.Benchmarks/CompareToLessThanBench.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/CompareToLessThanBench.cs
@@ -27,6 +27,7 @@ namespace DotNetCross.Sorting.Benchmarks
     [MemoryDiagnoser]
     //[DisassemblyDiagnoser(printSource: true, maxDepth: 2)]
     [SimpleJob(RunStrategy.Throughput, warmupCount: 5, targetCount: 15, id: "CompareJob")]
+    [IterationTime(50)]
     public abstract class CompareToLessThanBench<TComparable> 
         where TComparable : class, IComparable<TComparable>
     {

--- a/tests/DotNetCross.Sorting.Benchmarks/CompareToLessThanBench.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/CompareToLessThanBench.cs
@@ -14,6 +14,12 @@ namespace DotNetCross.Sorting.Benchmarks
             X = new ComparableClassInt32(12812912);
             Y = new ComparableClassInt32(12812913);
         }
+
+        [Benchmark]
+        public bool DirectCall()
+        {
+            return X.CompareTo(Y) < 0;
+        }
     }
 
     // Trying to benchmark the canonical generic issue and finding a work around
@@ -110,22 +116,22 @@ namespace DotNetCross.Sorting.Benchmarks
         public TComparable Y;
 
         [Benchmark]
-        public bool DirectCall()
+        public bool GenericDirectCall()
         {
             return X.CompareTo(Y) < 0;
         }
         [Benchmark]
-        public bool DirectCallWhereT()
+        public bool GenericDirectCallWhereT()
         {
             return ComparableDirectCallWhereT(X, Y);
         }
         [Benchmark]
-        public bool InterfaceCall()
+        public bool GenericInterfaceCall()
         {
             return ComparableInterfaceCall(X, Y);
         }
         [Benchmark]
-        public bool ValueType()
+        public bool GenericValueType()
         {
             //return m_comparer.LessThan(X, Y);
             return ComparerCall(X, Y, m_valueTypeComparer);
@@ -136,17 +142,17 @@ namespace DotNetCross.Sorting.Benchmarks
         //    return m_comparableComparerClosed.Invoke(Y) < 0;
         //}
         [Benchmark]
-        public bool InstanceOpenDelegate()
+        public bool GenericInstanceOpenDelegate()
         {
             return m_comparableComparerOpen.Invoke(X, Y) < 0;
         }
         [Benchmark]
-        public bool ComparableOpenDelegateObjectComparer()
+        public bool GenericComparableOpenDelegateObjectComparer()
         {
             return m_openDelegateObjectComparer.LessThan(X, Y);
         }
         [Benchmark]
-        public bool ComparableOpenDelegateObjectComparerWithChecks()
+        public bool GenericComparableOpenDelegateObjectComparerWithChecks()
         {
             return m_openDelegateObjectComparerWithChecks.LessThan(X, Y);
         }
@@ -166,6 +172,12 @@ namespace DotNetCross.Sorting.Benchmarks
         {
             return m_comparerComparableComparerOpen(m_defaultComparer, X, Y) < 0;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TResult DISASSEMBLE<TDelegate, T1, T2, TResult>(TDelegate compare, T1 x, T2 y)
+            where TDelegate : class, System.Delegate
+            => Unsafe.As<Func<T1, T2, TResult>>(compare)(x, y); 
+
 
         internal bool ComparableDirectCallWhereT<T>(T x, T y) where T : IComparable<T>
         {

--- a/tests/DotNetCross.Sorting.Benchmarks/CompareToLessThanBench.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/CompareToLessThanBench.cs
@@ -18,6 +18,7 @@ namespace DotNetCross.Sorting.Benchmarks
 
     // Trying to benchmark the canonical generic issue and finding a work around
     // delegate simply not fast enough, as expected, a direct function pointer might have been...
+    [MemoryDiagnoser]
     //[DisassemblyDiagnoser(printSource: true, maxDepth: 2)]
     [SimpleJob(RunStrategy.Throughput, warmupCount: 5, targetCount: 15, id: "CompareJob")]
     public abstract class CompareToLessThanBench<TComparable> 
@@ -63,7 +64,7 @@ namespace DotNetCross.Sorting.Benchmarks
         readonly Func<object, object, int> m_comparableComparerOpen = ComparableOpenDelegate<TComparable>();
         //readonly Func<TComparable, int> m_comparableComparerClosed;
         readonly IComparer<TComparable> m_defaultComparer;
-        readonly Func<TComparable, TComparable, int> m_comparerComparableComparerClosed =
+        readonly Comparison<TComparable> m_comparerComparableComparerClosed =
             Comparer<TComparable>.Default.Compare;
         readonly Func<object, object, object, int> m_comparerComparableComparerOpen =
             ComparerOpenDelegate<TComparable>();
@@ -125,7 +126,7 @@ namespace DotNetCross.Sorting.Benchmarks
             return m_comparableComparerOpen.Invoke(X, Y) < 0;
         }
         [Benchmark]
-        public bool InstanceOpenDelegateObjectComparer()
+        public bool ComparableOpenDelegateObjectComparer()
         {
             return m_openDelegateObjectComparer.LessThan(X, Y);
         }
@@ -160,7 +161,7 @@ namespace DotNetCross.Sorting.Benchmarks
             return comparer.LessThan(x, y);
         }
 
-        static Func<object, object, int> ComparableOpenDelegate<T>()
+        public static Func<object, object, int> ComparableOpenDelegate<T>()
             where T : class, IComparable<T>
         {
             var paramType = typeof(T);
@@ -175,7 +176,7 @@ namespace DotNetCross.Sorting.Benchmarks
             //return (x, y) => openTypedDelegate((T)x, (T)y);
         }
 
-        static Func<object, object, object, int> ComparerOpenDelegate<T>()
+        public static Func<object, object, object, int> ComparerOpenDelegate<T>()
             where T : class, IComparable<T>
         {
             var paramType = typeof(T);

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -212,7 +212,7 @@ namespace DotNetCross.Sorting.Benchmarks
 
             // TODO: Refactor to switch/case and methods perhaps, less flexible though
             // TODO: Add argument parsing for this perhaps
-            var d = Debugger.IsAttached ? Do.Loop1 : Do.Focus;
+            var d = Debugger.IsAttached ? Do.Loop1 : Do.Full;
             if (d == Do.Focus)
             {
                 BenchmarkRunner.Run<Int32SortBench>();

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -106,7 +106,7 @@ namespace DotNetCross.Sorting.Benchmarks
         {
             for (int i = 0; i <= _maxLength - Length; i += Length)
             {
-                ref object keys = ref Unsafe.AsRef<object>(_work[i]);
+                ref var keys = ref _work[i];
                 TDirectComparerImpl.IntroSort(ref keys, Length, 
                     new OpenDelegateObjectDirectComparer(m_comparableComparerOpen));
             }

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -63,8 +63,8 @@ namespace DotNetCross.Sorting.Benchmarks
     }
     public class ComparableClassInt32SortBench : SortBench<ComparableClassInt32>
     {
-        readonly Func<object, object, int> m_comparableComparerOpen = CompareToLessThanBench<ComparableClassInt32>
-            .ComparableOpenDelegate<ComparableClassInt32>();
+        readonly Comparison<object> m_comparableComparerOpen = DelegateDoctor
+            .GetComparableCompareToAsOpenObjectDelegate<ComparableClassInt32>();
 
         public ComparableClassInt32SortBench()
             : base(maxLength: 400000, new[] { 2, 3, 10, 100, 10000, 100000 },
@@ -169,9 +169,9 @@ namespace DotNetCross.Sorting.Benchmarks
 
         readonly struct OpenDelegateObjectDirectComparer : IDirectComparer<object>
         {
-            readonly Func<object, object, int> m_compare;
+            readonly Comparison<object> m_compare;
 
-            public OpenDelegateObjectDirectComparer(Func<object, object, int> compare) =>
+            public OpenDelegateObjectDirectComparer(Comparison<object> compare) =>
                 m_compare = compare;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -327,7 +327,7 @@ namespace DotNetCross.Sorting.Benchmarks
 
             // TODO: Refactor to switch/case and methods perhaps, less flexible though
             // TODO: Add argument parsing for this perhaps
-            var d = Debugger.IsAttached ? Do.Loop1 : Do.Focus;
+            var d = Debugger.IsAttached ? Do.Loop1 : Do.Micro;
             if (d == Do.Focus)
             {
                 //BenchmarkRunner.Run<Int32SortBench>();

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -91,6 +91,18 @@ namespace DotNetCross.Sorting.Benchmarks
             }
         }
 
+        ClassGenericDirectComparer<ComparableClassInt32> m_classGenericDirectComparer = 
+            new ClassGenericDirectComparer<ComparableClassInt32>();
+        [Benchmark]
+        public void DNX_ClassInterfaceDirectComparer()
+        {
+            for (int i = 0; i <= _maxLength - Length; i += Length)
+            {
+                ref var keys = ref _work[i];
+                TDirectComparerImpl.IntroSort(ref keys, Length, m_classGenericDirectComparer);
+            }
+        }
+
         [Benchmark]
         public void DNX_GenericDirectComparer()
         {
@@ -131,6 +143,17 @@ namespace DotNetCross.Sorting.Benchmarks
             public bool LessThan(IComparable<T> x, IComparable<T> y) => x.CompareTo(Unsafe.As<T>(y)) < 0;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool LessThanEqual(IComparable<T> x, IComparable<T> y) => x.CompareTo(Unsafe.As<T>(y)) <= 0;
+        }
+
+        sealed class ClassGenericDirectComparer<T> : IDirectComparer<T>
+            where T : IComparable<T>
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool GreaterThan(T x, T y) => x.CompareTo(y) > 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool LessThan(T x, T y) => x.CompareTo(y) < 0;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool LessThanEqual(T x, T y) => x.CompareTo(y) <= 0;
         }
 
         readonly struct GenericDirectComparer<T> : IDirectComparer<T>
@@ -395,9 +418,9 @@ namespace DotNetCross.Sorting.Benchmarks
 
                 sut.GlobalSetup();
                 sut.IterationSetup();
-                sut.DNX_StructComparableComparer();
+                sut.DNX_();
                 sut.IterationSetup();
-                sut.CLR_StructComparableComparer();
+                sut.DNX_OpenDelegateObjectDirectComparer();
 
                 //Console.WriteLine("Enter key...");
                 //Console.ReadKey();
@@ -405,9 +428,9 @@ namespace DotNetCross.Sorting.Benchmarks
                 for (int i = 0; i < 200; i++)
                 {
                     sut.IterationSetup();
-                    sut.DNX_StructComparableComparer();
+                    sut.DNX_();
                     sut.IterationSetup();
-                    sut.CLR_StructComparableComparer();
+                    sut.DNX_OpenDelegateObjectDirectComparer();
                 }
             }
         }

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using BenchmarkDotNet.Running;
 using DotNetCross.Sorting.Sequences;
 
@@ -61,6 +62,7 @@ namespace DotNetCross.Sorting.Benchmarks
                    SpanFillers.Default, i => new ComparableStructInt32(i))
         { }
     }
+    [InliningDiagnoser(true, true)]
     public class ComparableClassInt32SortBench : SortBench<ComparableClassInt32>
     {
         readonly Comparison<object> m_comparableComparisonOpen = DelegateDoctor
@@ -155,6 +157,16 @@ namespace DotNetCross.Sorting.Benchmarks
             }
         }
 
+        [Benchmark]
+        public void DNX_OpenDelegateObjectComparer()
+        {
+            for (int i = 0; i <= _maxLength - Length; i += Length)
+            {
+                new Span<ComparableClassInt32>(_work, i, Length)
+                    .IntroSort(new OpenDelegateObjectComparer(m_comparableComparisonOpen));
+            }
+        }
+
         readonly struct DirectComparer : IDirectComparer<ComparableClassInt32>
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -213,6 +225,19 @@ namespace DotNetCross.Sorting.Benchmarks
             public bool LessThanEqual(object x, object y) => m_compare(x, y) <= 0;
         }
 
+        // Methods with delegate calls cannot be inlined unfortunately! So have to give up.
+        // https://github.com/dotnet/runtime/issues/10048
+        readonly struct OpenDelegateObjectComparer : IComparer<object>
+        {
+            readonly Comparison<object> m_compare;
+
+            public OpenDelegateObjectComparer(Comparison<object> compare) =>
+                m_compare = compare;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int Compare(object x, object y) => m_compare(x, y);
+        }
+
         readonly struct OpenDelegateDirectComparer : IDirectComparer<ComparableClassInt32>
         {
             readonly Comparison<object> m_compare;
@@ -228,6 +253,23 @@ namespace DotNetCross.Sorting.Benchmarks
             public bool LessThanEqual(ComparableClassInt32 x, ComparableClassInt32 y) => m_compare(x, y) <= 0;
         }
 
+    }
+
+    public class Sample<T, TComparer>
+        where TComparer : IComparer<T>
+    {
+        public int Do(Span<T> s, T value, TComparer comparer)
+        {
+            int count = 0;
+            foreach (var v in s)
+            {
+                if (comparer.Compare(v, value) < 0)
+                {
+                    ++count;
+                }
+            }
+            return count;
+        }
     }
 
     public class Int32Int32SortBench : SortBench<int, int>
@@ -464,9 +506,9 @@ namespace DotNetCross.Sorting.Benchmarks
 
                 sut.GlobalSetup();
                 sut.IterationSetup();
-                sut.DNX_();
+                sut.DNX_Comparison_IComparable_OpenDelegate();
                 sut.IterationSetup();
-                sut.DNX_OpenDelegateObjectDirectComparer();
+                sut.DNX_OpenDelegateObjectComparer();
 
                 //Console.WriteLine("Enter key...");
                 //Console.ReadKey();
@@ -474,9 +516,9 @@ namespace DotNetCross.Sorting.Benchmarks
                 for (int i = 0; i < 200; i++)
                 {
                     sut.IterationSetup();
-                    sut.DNX_();
+                    sut.DNX_Comparison_IComparable_OpenDelegate();
                     sut.IterationSetup();
-                    sut.DNX_OpenDelegateObjectDirectComparer();
+                    sut.DNX_OpenDelegateObjectComparer();
                 }
             }
         }

--- a/tests/DotNetCross.Sorting.Benchmarks/Program.cs
+++ b/tests/DotNetCross.Sorting.Benchmarks/Program.cs
@@ -226,7 +226,8 @@ namespace DotNetCross.Sorting.Benchmarks
         }
 
         // Methods with delegate calls cannot be inlined unfortunately! So have to give up.
-        // https://github.com/dotnet/runtime/issues/10048
+        // https://github.com/dotnet/runtime/issues/35791 (issue filed by nietras)
+        // https://github.com/dotnet/runtime/issues/10048 (missed this before filing above)
         readonly struct OpenDelegateObjectComparer : IComparer<object>
         {
             readonly Comparison<object> m_compare;

--- a/tests/DotNetCross.Sorting.Tests/LowLevelTest.cs
+++ b/tests/DotNetCross.Sorting.Tests/LowLevelTest.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using Xunit;
+
+namespace DotNetCross.Sorting.Tests
+{
+    public class LowLevelTest
+    {
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        internal struct ComparisonAsStruct
+        {
+            [MarshalAs(UnmanagedType.FunctionPtr)]
+            internal Comparison<object> Delegate;
+        };
+
+        public class Comp
+            : IComparable<Comp>
+        {
+            public readonly int Value;
+
+            public Comp(int value) =>
+                Value = value;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public int CompareTo(Comp other) =>
+                Value.CompareTo(other.Value);
+        }
+
+        [Fact]
+        public unsafe void DelegateToPointer()
+        {
+            var compare = DelegateDoctor.GetComparableCompareToAsOpenObjectDelegate<Comp>();
+            var methodInfo = compare.Method;
+            var runtimeHandle = methodInfo.MethodHandle;
+            var functionPointer = runtimeHandle.GetFunctionPointer();
+
+            Assert.NotEqual(IntPtr.Zero, functionPointer);
+
+            //var asStruct = new ComparisonAsStruct() { Delegate = Unsafe.As<Comparison<object>>(compare) };
+            //IntPtr delegatePointer = IntPtr.Zero;
+            //void* pointerToDelegatePointer = &delegatePointer;
+            //Marshal.StructureToPtr(asStruct, new IntPtr(pointerToDelegatePointer), false);
+            //Assert.NotEqual(IntPtr.Zero, delegatePointer);
+        }
+    }
+}

--- a/tests/DotNetCross.Sorting.Tests/LowLevelTest.cs
+++ b/tests/DotNetCross.Sorting.Tests/LowLevelTest.cs
@@ -88,7 +88,7 @@ namespace DotNetCross.Sorting.Tests
 
             Assert.NotEqual(IntPtr.Zero, functionPointer);
 
-            var compareFromPtr = Marshal.GetDelegateForFunctionPointer<ComparisonComp>(functionPointer);
+            //var compareFromPtr = Marshal.GetDelegateForFunctionPointer<ComparisonComp>(functionPointer);
             // Below fails yielding incorrect results for some reason
             //Assert.Equal(-1, compareFromPtr(new Comp(-1), new Comp(1)));
             //Assert.Equal(0, compareFromPtr(new Comp(1), new Comp(1)));

--- a/tests/DotNetCross.Sorting.Tests/LowLevelTest.cs
+++ b/tests/DotNetCross.Sorting.Tests/LowLevelTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -31,6 +32,46 @@ namespace DotNetCross.Sorting.Tests
 
         // Marshal.GetDelegateForFunctionPointer does not work for generic delegates
         delegate int ComparisonComp(Comp x, Comp y);
+
+        [Fact]
+        public unsafe void ClassMethodToPointer()
+        {
+            IntPtr functionPointer = GetFunctionPointerComp();
+
+            Assert.NotEqual(IntPtr.Zero, functionPointer);
+        }
+
+        private static unsafe IntPtr GetFunctionPointerComp()
+        {
+            var paramType = typeof(Comp);
+            var comparableType = typeof(Comp);
+            const string methodName = nameof(IComparable<Comp>.CompareTo);
+            var methodInfo = comparableType.GetRuntimeMethod(methodName, new Type[] { paramType });
+
+            var runtimeHandle = methodInfo.MethodHandle;
+            var functionPointer = runtimeHandle.GetFunctionPointer();
+            return functionPointer;
+        }
+
+        [Fact]
+        public unsafe void InterfaceMethodToPointer()
+        {
+            IntPtr functionPointer = GetFunctionPointerCompAsIComparable();
+
+            Assert.NotEqual(IntPtr.Zero, functionPointer);
+        }
+
+        private static unsafe IntPtr GetFunctionPointerCompAsIComparable()
+        {
+            var paramType = typeof(Comp);
+            var comparableType = typeof(IComparable<Comp>);
+            const string methodName = nameof(IComparable<Comp>.CompareTo);
+            var methodInfo = comparableType.GetRuntimeMethod(methodName, new Type[] { paramType });
+
+            var runtimeHandle = methodInfo.MethodHandle;
+            var functionPointer = runtimeHandle.GetFunctionPointer();
+            return functionPointer;
+        }
 
         [Fact]
         public unsafe void DelegateToPointer()

--- a/tests/DotNetCross.Sorting.Tests/Sort.cs
+++ b/tests/DotNetCross.Sorting.Tests/Sort.cs
@@ -82,8 +82,8 @@ namespace System.SpanTests
             var original = new Span<BogusComparable>(values);
             var actual = original.ToArray().AsSpan();
             var expected = original.ToArray();
-            try { actual.IntroSort(Comparer<BogusComparable>.Default.Compare); } catch (Exception e) { }
-            try { Array.Sort(expected, Comparer<BogusComparable>.Default.Compare); } catch (Exception e) { }
+            try { actual.IntroSort(Comparer<BogusComparable>.Default.Compare); } catch (Exception ) { }
+            try { Array.Sort(expected, Comparer<BogusComparable>.Default.Compare); } catch (Exception ) { }
             Assert.Equal(expected, actual.ToArray());
         }
 


### PR DESCRIPTION
Methods with delegate calls cannot be inlined see https://github.com/dotnet/runtime/issues/10048
Neither can `calli` methods on older runtimes.
Hence, unification is not possible with perf impact and I am giving up on the futile attempt.
Calling an open delegate on a reference type `IComparable<T>` is faster than calling the interface instance method in benchmarks here so there is a possible use of the open delegate object comparison trick.